### PR TITLE
feat: Added validateHeaders function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ module.exports = () => {
     ctx.validateBody = validateBody.bind(null, ctx)
     ctx.validateParams = validateParams.bind(null, ctx)
     ctx.validateQuery = validateQuery.bind(null, ctx)
+    ctx.validateHeaders = validateHeaders.bind(null, ctx)
     await next()
   }
 }
@@ -19,6 +20,10 @@ function validateParams (ctx, rule) {
 
 function validateQuery (ctx, rule) {
   validate(ctx.request.query, rule)
+}
+
+function validateHeaders (ctx, rule) {
+  validate(ctx.request.headers, rule)
 }
 
 function validate (obj, rule) {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -7,7 +7,8 @@ const myValidator = validator()
 
 
 const context = {
-  request: {}
+  request: {},
+  headers: {}
 }
 
 describe('validator', async () => {
@@ -41,9 +42,14 @@ describe('validator', async () => {
     expect(context.validateParams).to.be.a('function')
   })
 
-  it('should add a validateQuery function to context', async () => {
+  it('should added a validateQuery function to context', async () => {
     await myValidator(context, ()=>{})
     expect(context.validateQuery).to.be.a('function')
+  })
+
+  it('should added a validateHeaders function to context', async () => {
+    await myValidator(context, ()=>{})
+    expect(context.validateHeaders).to.be.a('function')
   })
 })
 
@@ -111,3 +117,23 @@ describe('validateQuery', () => {
   })
 })
 
+describe('validateHeaders', () => {
+  const rule = joi.object().keys({
+    name: joi.string().required(),
+    age: joi.number().required()
+  })
+
+  it('should call validate function on joi object', async function () {
+    const validate = this.sandbox.spy(joi, 'validate')
+    await myValidator(context, () => {})
+    context.validateHeaders(rule)
+    expect(validate).to.be.calledOnce
+  })
+
+  it('should call validate function on joi object with 3 arguments', async function () {
+    const validate = this.sandbox.spy(joi, 'validate')
+    await myValidator(context, () => {})
+    context.validateHeaders(rule)
+    expect(validate.firstCall.args.length).to.be.equal(3)
+  })
+})


### PR DESCRIPTION
ValidateHeaders allows validate header keys using joi rules, for example: format of api-key,
api-version, etc